### PR TITLE
⚡ Set image dimensions on html tag

### DIFF
--- a/app/components/games/card_component.html.erb
+++ b/app/components/games/card_component.html.erb
@@ -1,7 +1,7 @@
 <div class="card border border-gray-700 bg-base-200">
   <%= link_to game_path(game.slug) do %>
     <figure class="w-full aspect-video">
-      <%= image_tag game.small_banner_url, alt: game.title, loading: :lazy, class: "w-full" %>
+      <%= image_tag game.small_banner_url, class: "w-full", width: 480, height: 320, alt: game.title, loading: :lazy %>
     </figure>
   <% end %>
 

--- a/app/components/item_details/thumbnails_section_component.html.erb
+++ b/app/components/item_details/thumbnails_section_component.html.erb
@@ -3,11 +3,11 @@
     <div class="splide__track">
       <ul class="splide__list">
         <li class="splide__slide">
-          <%= image_tag item.banner_url, class: "w-full aspect-video" %>
+          <%= image_tag item.banner_url, class: "w-full aspect-video", width: 720, height: 480 %>
         </li>
         <% item.screenshot_urls.each do |image_url| %>
           <li class="splide__slide">
-            <%= image_tag image_url, class: "w-full aspect-video" %>
+            <%= image_tag image_url, class: "w-full aspect-video", width: 720, height: 480 %>
           </li>
         <% end %>
       </ul>
@@ -18,11 +18,11 @@
     <div class="splide__track">
       <ul class="splide__list">
         <li class="splide__slide">
-          <%= image_tag item.banner_url %>
+          <%= image_tag item.small_banner_url, width: 480, height: 320 %>
         </li>
         <% item.screenshot_urls.each do |image_url| %>
           <li class="splide__slide">
-            <%= image_tag image_url %>
+            <%= image_tag image_url, width: 480, height: 320 %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn more](https://web.dev/optimize-cls/?utm_source=lighthouse&utm_medium=lr#images-without-dimensions)